### PR TITLE
Profile photo, 3 new case studies, color fix, and grid layout improvements

### DIFF
--- a/case-studies/style.css
+++ b/case-studies/style.css
@@ -20,10 +20,10 @@
   --text-muted:    #7b8599;
   --text-dim:      #3c4560;
 
-  --accent:        #7c6dff;
-  --accent-soft:   rgba(124, 109, 255, 0.12);
-  --accent-border: rgba(124, 109, 255, 0.30);
-  --accent-glow:   rgba(124, 109, 255, 0.25);
+  --accent:        #4f80ff;
+  --accent-soft:   rgba(79, 128, 255, 0.11);
+  --accent-border: rgba(79, 128, 255, 0.28);
+  --accent-glow:   rgba(79, 128, 255, 0.20);
 
   --green:         #34d399;
   --green-soft:    rgba(52, 211, 153, 0.10);

--- a/index.html
+++ b/index.html
@@ -55,10 +55,10 @@
       --text-dim:     #3c4560;
 
       /* Accent (violet) */
-      --accent:        #7c6dff;
-      --accent-soft:   rgba(124, 109, 255, 0.12);
-      --accent-border: rgba(124, 109, 255, 0.30);
-      --accent-glow:   rgba(124, 109, 255, 0.25);
+      --accent:        #4f80ff;
+      --accent-soft:   rgba(79, 128, 255, 0.11);
+      --accent-border: rgba(79, 128, 255, 0.28);
+      --accent-glow:   rgba(79, 128, 255, 0.20);
 
       /* Status green */
       --green:      #34d399;
@@ -174,7 +174,7 @@
       color: #fff;
     }
     .btn-primary:hover {
-      background: #6554e8;
+      background: #3a6bf0;
       transform: translateY(-1px);
       box-shadow: 0 6px 24px var(--accent-glow);
     }
@@ -287,7 +287,7 @@
       padding: 7px 18px;
       font-weight: 500;
     }
-    .nav-links .nav-cta a:hover { background: #6554e8; }
+    .nav-links .nav-cta a:hover { background: #3a6bf0; }
 
     /* Hamburger (mobile) */
     .nav-toggle {
@@ -507,7 +507,8 @@
       grid-template-columns: repeat(2, 1fr);
       gap: 16px;
     }
-    .project-card:last-child { grid-column: 1 / -1; }
+    .project-card.featured { grid-column: 1 / -1; }
+    .project-card:not(.featured):last-child { grid-column: 1 / -1; }
 
     /* ── Project card ── */
     .project-card {


### PR DESCRIPTION
## Summary

- Added profile photo in About section (`assets/profile.jpg`)
- Added 3 new case studies: GTM Org Build, Salesforce CPQ Deployment, GTM Analytics & KPI Framework
- Anonymized all company names across case study pages (industry descriptors instead of Postman/HashiCorp)
- Fixed LinkedIn icon (inline SVG replacing broken Lucide branded icon)
- Reverted accent color to blue (`#4f80ff`) after testing violet
- Fixed project card grid: featured card spans full width by class, last non-featured card anchors the bottom row full-width — all other cards pair evenly in 2 columns
- Updated tool references in case studies (Clay, Gong Engage, Demandbase emphasized)
- Changed "freelance" → "consulting" throughout

## Notes
All 8 case studies are linked in a sequential navigation chain. Profile photo served from `assets/profile.jpg`.