### PR TITLE
Portfolio content updates: new case studies, agentic workflow rewrite, analytics fixes

### DIFF
--- a/case-studies/agentic-gtm-workflow.html
+++ b/case-studies/agentic-gtm-workflow.html
@@ -35,7 +35,7 @@
     <div class="cs-meta">
       <span class="badge badge-accent">AI</span>
       <span class="badge badge-accent">Agentic</span>
-      <span class="cs-company">Independent</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">Agentic GTM Workflow</h1>
     <p class="cs-tagline">An n8n + Claude AI workflow that autonomously researches prospects, updates CRM fields, and enrolls high-fit accounts in sequences — cutting 20+ minutes of manual work per account to under 2.</p>

--- a/case-studies/agentic-gtm-workflow.html
+++ b/case-studies/agentic-gtm-workflow.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Case Study: Agentic GTM Workflow — How Roshan Lal built an n8n + Claude AI workflow that autonomously handles prospect research, CRM updates, and outreach sequencing." />
-  <meta property="og:title" content="Agentic GTM Workflow — Roshan Lal" />
-  <meta property="og:description" content="n8n + Claude AI workflow that cuts prospect research from 20+ minutes to under 2 minutes per account, with autonomous CRM updates and sequence enrollment." />
-  <title>Agentic GTM Workflow — Roshan Lal</title>
+  <meta name="description" content="Case Study: Agentic Deal Signal Monitor — How Roshan Lal built an n8n + Claude workflow that watches Salesforce and Gong for deal risk signals and delivers actionable Slack alerts before deals go cold." />
+  <meta property="og:title" content="Agentic Deal Signal Monitor — Roshan Lal" />
+  <meta property="og:description" content="n8n + Claude workflow that monitors open pipeline for stagnation, champion changes, and missed next steps — delivering context-rich Slack alerts to reps and managers before deals go cold." />
+  <title>Agentic Deal Signal Monitor — Roshan Lal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -37,29 +37,28 @@
       <span class="badge badge-accent">Agentic</span>
       <span class="cs-company">Developer Tools</span>
     </div>
-    <h1 class="cs-title">Agentic GTM Workflow</h1>
-    <p class="cs-tagline">An n8n + Claude AI workflow that autonomously researches prospects, updates CRM fields, and enrolls high-fit accounts in sequences — cutting 20+ minutes of manual work per account to under 2.</p>
+    <h1 class="cs-title">Agentic Deal Signal Monitor</h1>
+    <p class="cs-tagline">An n8n + Claude workflow that watches Salesforce and Gong for deal risk signals — stagnation, champion changes, missed next steps, competitor mentions — and delivers context-rich Slack alerts to the right rep or manager before deals go cold.</p>
     <div class="cs-tags">
       <span class="tag">n8n</span>
       <span class="tag">Claude AI</span>
-      <span class="tag">Clay</span>
       <span class="tag">Salesforce</span>
-      <span class="tag">Gong Engage</span>
-      <span class="tag">Demandbase</span>
+      <span class="tag">Gong</span>
+      <span class="tag">Slack</span>
       <span class="tag">Agentic</span>
     </div>
     <div class="cs-stats">
       <div class="cs-stat">
-        <span class="cs-stat-num">&gt;90%</span>
-        <span class="cs-stat-lbl">Reduction in research time per account</span>
-      </div>
-      <div class="cs-stat">
-        <span class="cs-stat-num">85%+</span>
-        <span class="cs-stat-lbl">CRM field completeness (automated)</span>
+        <span class="cs-stat-num">100%</span>
+        <span class="cs-stat-lbl">Open pipeline actively monitored</span>
       </div>
       <div class="cs-stat">
         <span class="cs-stat-num">&lt;5 min</span>
-        <span class="cs-stat-lbl">Trigger to sequence enrollment</span>
+        <span class="cs-stat-lbl">Signal detected to Slack alert delivered</span>
+      </div>
+      <div class="cs-stat">
+        <span class="cs-stat-num">75%+</span>
+        <span class="cs-stat-lbl">Alerts result in logged Salesforce activity within 48h</span>
       </div>
     </div>
   </div>
@@ -70,124 +69,125 @@
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Problem</p>
-      <h2 class="cs-section-title">GTM teams are doing knowledge work that machines should be doing. The research, the routing decisions, the CRM updates — it's all automatable.</h2>
-      <p>Look at how a typical SDR or AE spends their first hour on a new prospect: they open LinkedIn, read the company website, check for recent news, search Salesforce for existing activity, look up the contact in a data provider, write a personalized note in Gong Engage, and then manually update six CRM fields. <strong>That's 20–30 minutes of work before a single value-creating interaction happens.</strong></p>
-      <p>Multiply that by 30–50 new accounts per week per rep, and you're looking at entire workdays consumed by research that follows near-identical patterns every time. It's rule-based enough to automate but complex enough — synthesizing multiple data sources into a coherent assessment — that simple Zapier workflows can't handle it.</p>
+      <h2 class="cs-section-title">Deals don't die in one moment — they erode over weeks. The signals are in the data. Nobody's reading them.</h2>
+      <p>A champion goes quiet after a promising call. An opportunity hasn't moved stages in three weeks. A contact who was the primary buyer just left the company. A Gong transcript from last Tuesday has the customer mentioning a competitor — and nobody flagged it. <strong>All of this is in the data. None of it is reaching anyone in time to act.</strong></p>
+      <p>With 40–60 open opportunities per rep, "actively monitoring your pipeline for risk signals" doesn't happen consistently. Reps review their Salesforce reports on Monday morning. By Friday, a deal that's been dark for 18 days is still dark — and the first time a manager hears about it is during a forecast call when it's too late to change the outcome.</p>
 
-      <div class="callout">
-        <strong>This is exactly the problem LLMs solve.</strong> They're not good at reliable data retrieval, but they're exceptional at reading context from multiple sources and synthesizing a coherent recommendation. Pair an LLM with a reliable workflow orchestrator, and you have the foundation for a genuine GTM agent.
+      <div class="callout callout-amber">
+        <strong>The problem isn't a data problem — it's an attention problem.</strong> Salesforce has the stagnation data. Gong has the call intelligence. What was missing was a layer that connected those signals to the right person at the moment action was still possible — without requiring that person to go looking.
       </div>
 
       <ul class="cs-list">
-        <li><strong>20–30 min of research per account</strong> — time that grows linearly with pipeline targets</li>
-        <li><strong>Inconsistent research quality</strong> — what a rep finds depends on how thorough they are that day</li>
-        <li><strong>Delayed sequence enrollment</strong> — accounts sit in queues for hours or days before outreach begins</li>
-        <li><strong>Sparse CRM data</strong> — manual entry means incomplete records, broken reporting, and poor attribution</li>
+        <li><strong>Deal stagnation invisible until forecast:</strong> deals sitting dark for weeks with no automated alert — managers discovering at-risk pipeline in QBRs, not 3 weeks earlier</li>
+        <li><strong>Gong insights siloed:</strong> call transcripts captured but not acted on — competitor mentions and procurement objections buried in recordings nobody re-watched</li>
+        <li><strong>Champion departures missed:</strong> no monitoring for contact changes at key accounts — reps finding out their champion left from a bounce email, not a proactive alert</li>
+        <li><strong>Missed next steps uncaught:</strong> next step dates passing with no activity logged and no flag to anyone</li>
+        <li><strong>Rep attention split:</strong> reps working inbound and outbound simultaneously had no triage system telling them which existing deals needed attention most urgently</li>
       </ul>
     </div>
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Approach</p>
-      <h2 class="cs-section-title">Design for the full workflow, not just the research step. Build human checkpoints in from the start.</h2>
-      <p>The design principle I started with: <strong>an agent that does 90% of the work autonomously and surfaces the remaining 10% for human review is more valuable than one that tries to do 100% and gets it wrong</strong>. GTM agents fail when they optimize for automation completeness over decision quality.</p>
-      <p>I chose n8n as the orchestration layer because it's open source, self-hostable, supports 400+ native integrations, and has strong branching logic for the conditional decisions an agentic workflow requires. Claude was the LLM choice — specifically for its long context window (needed to process multi-source research) and its reliability on synthesis tasks vs. data hallucination.</p>
-      <p>The workflow scope was deliberately narrow for v1: <strong>research → score → enrich CRM → sequence decision</strong>. No email generation, no autonomous outreach — those came in v2 once the research and scoring layer was validated.</p>
+      <h2 class="cs-section-title">Monitor continuously. Synthesize context. Deliver alerts specific enough to act on immediately.</h2>
+      <p>The design principle I started with: <strong>a generic alert gets ignored; a specific alert gets acted on</strong>. "This deal hasn't moved in 21 days" is noise. "Acme Corp — no contact in 19 days. Last call: champion mentioned procurement freeze in Q2. Suggested action: executive re-engagement before Q2 closes" is something a rep opens and responds to within the hour.</p>
+      <p>I chose n8n as the monitoring and orchestration layer — open source, self-hostable, with native connectors for Salesforce, Gong, and Slack, and strong conditional branching for the routing logic. Claude was the synthesis layer: reading the assembled deal context and writing the alert summary in plain language a rep could act on without needing to open Salesforce first.</p>
+      <p>Critically, I designed the alert routing to match the urgency and deal size. A deal stagnating 10 days before its expected close date at $200K ARR routes differently than a $15K deal that's been quiet for a week. <strong>Alert fatigue kills adoption faster than any technical failure</strong> — so deduplication and routing thresholds were designed before a single alert was built.</p>
     </div>
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Build</p>
-      <h2 class="cs-section-title">Five-step agentic loop: research → score → update CRM → decide → enroll or escalate.</h2>
+      <h2 class="cs-section-title">Five-layer system: signal definitions → monitoring → synthesis → routing → Slack delivery with Salesforce writeback.</h2>
 
       <div class="steps">
         <div class="step">
           <div class="step-num">01</div>
           <div class="step-content">
-            <div class="step-title">Trigger — New account enters target list in Salesforce</div>
-            <div class="step-desc">n8n listens for Salesforce webhook: new lead created, account stage change, or manual "research trigger" field set by a rep. Immediately kicks off the research pipeline — no batch delays.</div>
+            <div class="step-title">Signal definitions — What counts as a risk trigger</div>
+            <div class="step-desc">Defined five monitored signal types with configurable thresholds: deal stagnation (no stage progression in N days, tiered by deal size), contact inactivity (no calls or emails logged in N days), champion departure (primary contact changed jobs, via data provider monitoring), Gong call signals (competitor mention, pricing objection, procurement delay — extracted from transcripts), and missed next steps (next step date passed with no activity logged). Thresholds reviewed with VP Sales before launch.</div>
           </div>
         </div>
         <div class="step">
           <div class="step-num">02</div>
           <div class="step-content">
-            <div class="step-title">Research Agent — Multi-source data gathering</div>
-            <div class="step-desc">n8n pulls in parallel: company website content (via web content scraping), recent news (via News API), LinkedIn company page summary, Clay for firmographic and demographic enrichment, ZoomInfo firmographics, existing Salesforce activity history, job posting data (growth signal), product usage signals (in-app behavior and engagement data), and web traffic and intent data via Demandbase. All context assembled into a single prompt payload.</div>
+            <div class="step-title">n8n monitoring layer — Scheduled checks and event-driven triggers</div>
+            <div class="step-desc">Two trigger types: scheduled (nightly Salesforce polling for stagnation, inactivity, and missed next steps) and event-driven (Gong webhook fires on call completion, triggering real-time transcript analysis). Deduplication logic prevents the same deal alerting more than once per signal type within a 5-day window — preventing the alert fatigue that kills adoption.</div>
           </div>
         </div>
         <div class="step">
           <div class="step-num">03</div>
           <div class="step-content">
-            <div class="step-title">Scoring Agent — Claude synthesizes and scores</div>
-            <div class="step-desc">Claude receives the full research context and returns: ICP fit score (1–5), trigger strength (weak / moderate / strong), a one-sentence "why now" summary, and a recommended action (sequence A, sequence B, or hold for human review). Structured JSON output for reliable downstream parsing.</div>
+            <div class="step-title">Claude synthesis — Context-aware alert generation</div>
+            <div class="step-desc">For each triggered signal, Claude receives the full deal context: opportunity details, stage history, activity log, Gong call summary where relevant, and account history. Returns a structured JSON payload: 2–3 sentence situation summary in plain English, the specific risk identified, and a concrete recommended action. The summary is written as if Claude is a deal coach briefing the rep — specific to this deal, not a generic template.</div>
           </div>
         </div>
         <div class="step">
           <div class="step-num">04</div>
           <div class="step-content">
-            <div class="step-title">CRM Enrichment — Write back to Salesforce</div>
-            <div class="step-desc">n8n writes AI score, trigger summary, research-derived fields (tech stack, recent news, key contacts), and data source timestamps back to Salesforce. Fields visible in the rep's lead/account view so context is available before any human interaction.</div>
+            <div class="step-title">Smart routing — Right alert to the right person</div>
+            <div class="step-desc">Three routing tiers: rep-only (standard deals within normal stagnation window), rep + manager CC (deals above $75K ARR or stagnation beyond 30 days), VP alert (commit-forecast deals with no contact in 14+ days). Routing logic in n8n — no hardcoded rep lists, pulls org hierarchy from Salesforce dynamically so it stays current as the team changes.</div>
           </div>
         </div>
         <div class="step">
           <div class="step-num">05</div>
           <div class="step-content">
-            <div class="step-title">Sequence Decision — Enroll or escalate</div>
-            <div class="step-desc">Score ≥ 4: auto-enroll in appropriate Gong Engage sequence based on persona/segment. Score 2–3: send Slack notification to rep with full context for human decision. Score ≤ 1: tag account as low-priority, skip sequencing, log for quarterly review.</div>
+            <div class="step-title">Slack delivery + Salesforce writeback</div>
+            <div class="step-desc">Rich Slack message: deal name, ARR, close date, days since last activity, AI-generated situation summary, and four quick-action buttons (Log a call, Update next steps, Flag for manager review, Snooze 3 days). Button actions write back to Salesforce via n8n webhooks in real time — so the rep's response to the alert is captured in CRM without them opening a browser.</div>
           </div>
         </div>
       </div>
 
       <div class="callout" style="margin-top: 32px;">
-        <strong>The human escalation path was built first, not last.</strong> Before the happy path worked end-to-end, I made sure low-confidence accounts had a clear handoff to a human with full context. This is what makes the system trustworthy — reps know that if Claude isn't confident, they'll hear about it.
+        <strong>The Slack quick-action buttons were the most underrated design decision.</strong> Before them, reps would read an alert and then lose momentum context-switching to Salesforce to log the follow-up. With in-Slack actions, the gap between "I got the alert" and "I logged a response" dropped to under 60 seconds.
       </div>
     </div>
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Results</p>
-      <h2 class="cs-section-title">Research that took 20+ minutes per account now takes under 2. CRM data that used to require manual entry now fills itself.</h2>
+      <h2 class="cs-section-title">Every deal in pipeline monitored. Signals reaching reps in minutes. At-risk deals surfaced while there's still time to act.</h2>
 
       <div class="results-grid">
         <div class="result-card">
-          <span class="result-num">&gt;90%</span>
-          <div class="result-label">Research time cut</div>
-          <div class="result-desc">Per-account research time dropped from 20–30 minutes to under 2 minutes of human review — the agent does the rest.</div>
+          <span class="result-num">100%</span>
+          <div class="result-label">Pipeline coverage</div>
+          <div class="result-desc">Every open opportunity monitored continuously — no deal goes dark without a signal reaching the right person. Previously, monitoring was limited to whatever a rep manually reviewed each week.</div>
         </div>
         <div class="result-card">
-          <span class="result-num">85%+</span>
-          <div class="result-label">CRM field completeness</div>
-          <div class="result-desc">Salesforce records populated automatically with enriched data, AI scores, and trigger summaries — no manual entry required.</div>
+          <span class="result-num">75%+</span>
+          <div class="result-label">Alert-to-action rate</div>
+          <div class="result-desc">More than 75% of delivered alerts result in a logged Salesforce activity within 48 hours — confirming the alerts are specific enough to act on, not generic enough to ignore.</div>
         </div>
         <div class="result-card">
           <span class="result-num">&lt;5 min</span>
-          <div class="result-label">Trigger to sequence enrollment</div>
-          <div class="result-desc">High-scoring accounts enter Gong Engage sequences within minutes of the trigger — vs. hours or days with manual processes.</div>
+          <div class="result-label">Signal to alert</div>
+          <div class="result-desc">Gong call completes → transcript analyzed → Claude synthesizes → Slack alert delivered in under 5 minutes. Deal stagnation checks run nightly with alerts delivered before the start of the next business day.</div>
         </div>
         <div class="result-card">
-          <span class="result-num">Redirected</span>
-          <div class="result-label">SDR capacity</div>
-          <div class="result-desc">Time recaptured from research was redirected to actual selling — call prep, discovery, and follow-up rather than data gathering.</div>
+          <span class="result-num">Earlier</span>
+          <div class="result-label">At-risk deal visibility</div>
+          <div class="result-desc">Managers seeing at-risk pipeline weeks earlier than before — in time to coach, re-engage, or escalate. The shift: from discovering risk in forecast calls to managing it proactively.</div>
         </div>
       </div>
     </div>
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">Key Takeaways</p>
-      <h2 class="cs-section-title">What I learned building my first production GTM agent.</h2>
+      <h2 class="cs-section-title">What I learned building a production deal monitoring agent.</h2>
       <div class="takeaways">
         <div class="takeaway">
           <span class="takeaway-icon">🎯</span>
-          <span><strong>Scope the agent tightly for v1.</strong> The temptation is to automate everything. Resist it. Start with the highest-value, most repeatable step (research) and validate that it's accurate before expanding. Every scope addition is a new failure mode to manage.</span>
+          <span><strong>Specificity is what separates an alert from noise.</strong> A message telling a rep their deal is stagnating gets dismissed. A message telling them exactly what happened on the last call, why that's a risk, and what to do about it gets acted on. Claude's synthesis step — writing the situation summary — is the most important part of the system.</span>
         </div>
         <div class="takeaway">
-          <span class="takeaway-icon">📋</span>
-          <span><strong>Structured output is not optional.</strong> If Claude returns free-form text, downstream parsing breaks unpredictably. Define the exact JSON schema you need and prompt for it explicitly. Add validation in n8n so malformed responses trigger a fallback, not a broken workflow.</span>
+          <span class="takeaway-icon">🔇</span>
+          <span><strong>Alert fatigue will kill adoption before any technical failure does.</strong> Build deduplication and routing thresholds before building the first alert. If reps start ignoring alerts because they're too frequent or too generic, you'll never recover their trust — even after you fix the underlying issue.</span>
         </div>
         <div class="takeaway">
-          <span class="takeaway-icon">🧠</span>
-          <span><strong>LLMs are synthesizers, not databases.</strong> Claude shouldn't be fetching data — it should be reading data and making judgments. Keep data retrieval in n8n where it's reliable and deterministic. Give Claude the assembled context and ask for the reasoning.</span>
+          <span class="takeaway-icon">⚡</span>
+          <span><strong>Close the action loop inside the alert.</strong> Slack quick-action buttons that write back to Salesforce eliminated the context-switch that was the biggest friction point in the pre-build workflow. The fewer steps between "I read the alert" and "I took action," the higher the response rate.</span>
         </div>
         <div class="takeaway">
-          <span class="takeaway-icon">👤</span>
-          <span><strong>Trust is built through the escalation path, not the automation path.</strong> Reps adopt agentic tools when they trust them. That trust comes from seeing the system gracefully hand off uncertain cases to humans — not from watching it barrel through low-confidence decisions autonomously.</span>
+          <span class="takeaway-icon">📐</span>
+          <span><strong>Routing logic is a business design problem, not a technical one.</strong> What deal size triggers a manager CC? How many days of silence before a VP alert? These decisions require VP Sales input, not engineering judgment. Get alignment on routing thresholds before launch — changing them after reps have already formed habits is painful.</span>
         </div>
       </div>
     </div>
@@ -197,8 +197,8 @@
 
 <div class="cs-cta">
   <div class="container">
-    <h2>Want to build a GTM agent?</h2>
-    <p>I design and deploy agentic workflows for GTM teams using n8n, Claude, and your existing stack. From scoping to production in 3–5 weeks.</p>
+    <h2>Want pipeline risk surfaced before it becomes a forecast problem?</h2>
+    <p>I design and deploy agentic monitoring workflows for GTM teams using n8n, Claude, and your existing stack. From scoping to production in 3–5 weeks.</p>
     <div class="cs-cta-btns">
       <a href="../index.html#contact" class="btn btn-primary"><i data-lucide="mail" width="15" height="15"></i> Get in Touch</a>
       <a href="../index.html#projects" class="btn btn-ghost">View All Projects</a>

--- a/case-studies/ai-enrichment-engine.html
+++ b/case-studies/ai-enrichment-engine.html
@@ -41,7 +41,7 @@
     <div class="cs-meta">
       <span class="badge badge-accent">AI</span>
       <span class="badge badge-green">Live</span>
-      <span class="cs-company">Developer Tools · Series D</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">AI-Powered Enrichment Engine</h1>
     <p class="cs-tagline">Replacing 2.5 hours of daily manual research with a Clay-based workflow that surfaces real-time buying signals — so reps spend time selling, not searching.</p>

--- a/case-studies/flexible-consumption.html
+++ b/case-studies/flexible-consumption.html
@@ -34,7 +34,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Shipped</span>
-      <span class="cs-company">Cloud Infrastructure · IPO</span>
+      <span class="cs-company">Cloud Infrastructure</span>
     </div>
     <h1 class="cs-title">Flexible Consumption GTM Launch</h1>
     <p class="cs-tagline">Business Systems lead for a cloud platform product's shift to usage-based billing — wiring the full order-to-revenue flow for a new monetization model that generated $5M+ ARR in its first year.</p>

--- a/case-studies/flexible-consumption.html
+++ b/case-studies/flexible-consumption.html
@@ -43,7 +43,7 @@
       <span class="tag">Billing Systems</span>
       <span class="tag">Usage-Based Billing</span>
       <span class="tag">Revenue Recognition</span>
-      <span class="tag">Snowflake</span>
+      <span class="tag">NetSuite</span>
       <span class="tag">RevOps</span>
     </div>
     <div class="cs-stats">
@@ -92,7 +92,7 @@
       <p>I formed a working pod with representatives from GTM, Product, Engineering, Finance, and PMM — meeting weekly with clear decision rights on each domain. Misalignment at this stage is expensive. We resolved it in rooms before it became code.</p>
 
       <div class="callout">
-        The key early decision: <strong>extend Salesforce vs. buy a purpose-built billing platform</strong>. We chose to extend Salesforce — keeping GTM's single source of truth intact and avoiding a new platform adoption cycle inside a 6-month window. The tradeoff was more complex data modeling. It was the right call.
+        The key early decision: <strong>build a billing backend vs. buy a purpose-built billing platform</strong>. Engineering built a custom billing backend that integrated directly with Salesforce — keeping GTM's single source of truth intact and avoiding a new platform adoption cycle inside a 6-month window. Salesforce then integrated with NetSuite for financial reporting and customer invoicing. The tradeoff was more complex data modeling. It was the right call.
       </div>
 
       <p>I sequenced the build around dependencies: data model first, then the metering pipeline, then CPQ quoting flows, then rev rec configuration, then rep enablement. Each layer had to be stable before the next could be built reliably.</p>
@@ -113,8 +113,8 @@
         <div class="step">
           <div class="step-num">02</div>
           <div class="step-content">
-            <div class="step-title">Metering pipeline — Engineering APIs → Snowflake → Salesforce</div>
-            <div class="step-desc">Partnered with Engineering to expose usage events via API. Built a Snowflake transformation layer to aggregate raw events into billable usage summaries. Nightly sync to Salesforce via Apex batch jobs, with real-time alerting on pipeline failures.</div>
+            <div class="step-title">Billing backend — Engineering-built system integrated with Salesforce</div>
+            <div class="step-desc">Partnered with Engineering to build a billing backend that tracked usage events, calculated consumption against committed credits, and surfaced billing summaries into Salesforce. This system became the authoritative source of usage data, feeding the Consumption Contract and Credit Balance objects in real time. Defined the data contract between Engineering and GTM systems to ensure accuracy across both.</div>
           </div>
         </div>
         <div class="step">
@@ -127,8 +127,8 @@
         <div class="step">
           <div class="step-num">04</div>
           <div class="step-content">
-            <div class="step-title">Revenue recognition — Ratable recognition over consumption periods</div>
-            <div class="step-desc">Configured rev rec rules for consumption contracts: credit packs recognized ratably over the contract term, on-demand recognized as consumed. Coordinated with Finance to validate against ASC 606 requirements before go-live.</div>
+            <div class="step-title">NetSuite integration — Salesforce to invoicing</div>
+            <div class="step-desc">Built the Salesforce → NetSuite integration to push consumption billing data downstream. At the end of each billing period, Salesforce usage summaries flowed into NetSuite to generate monthly usage invoices sent to customers. Coordinated with Finance on rev rec rules: credit packs recognized ratably over the contract term, on-demand recognized as consumed, validated against ASC 606 before go-live.</div>
           </div>
         </div>
         <div class="step">
@@ -159,7 +159,7 @@
         <div class="result-card">
           <span class="result-num">100%</span>
           <div class="result-label">Automated billing pipeline</div>
-          <div class="result-desc">Usage-to-invoice cycle fully automated — no manual calculation or intervention required for standard consumption contracts.</div>
+          <div class="result-desc">End-to-end usage-to-invoice cycle fully automated: Engineering billing backend → Salesforce → NetSuite → monthly customer invoice. No manual calculation or intervention required for standard consumption contracts.</div>
         </div>
         <div class="result-card">
           <span class="result-num">Template</span>

--- a/case-studies/gtm-analytics.html
+++ b/case-studies/gtm-analytics.html
@@ -33,7 +33,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Live</span>
-      <span class="cs-company">Infrastructure Software · Pre-IPO</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">GTM Analytics & KPI Framework</h1>
     <p class="cs-tagline">Built the metrics infrastructure and analytical frameworks that powered weekly marketing and sales reviews, monthly GTM reporting, and quarterly board decks — establishing a single source of truth for revenue performance across a pre-IPO org.</p>

--- a/case-studies/gtm-analytics.html
+++ b/case-studies/gtm-analytics.html
@@ -68,7 +68,7 @@
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Problem</p>
       <h2 class="cs-section-title">Every team was running their own numbers. Board decks were built manually every quarter. No one agreed on what "pipeline" meant.</h2>
-      <p>At a pre-IPO infrastructure software company, the GTM org had grown fast enough that each function — Sales, Marketing, and CS — had developed their own reporting cadence, their own metric definitions, and their own data pulls. The result was the classic symptom of analytics at scale: <strong>every leadership meeting started with 15 minutes of arguing about whose numbers were right</strong> before the actual work could begin.</p>
+      <p>At a pre-IPO infrastructure software company, the GTM org had grown fast enough that each function — Sales and Marketing — had developed their own reporting cadence, their own metric definitions, and their own data pulls. The result was the classic symptom of analytics at scale: <strong>every leadership meeting started with 15 minutes of arguing about whose numbers were right</strong> before the actual work could begin.</p>
       <p>Quarterly board decks were built manually by a RevOps analyst spending 2–3 days pulling data from Salesforce reports, reformatting in Excel, and assembling slides — a process so fragile that a single data refresh could cascade into hours of reconciliation. There was no BI layer connecting the underlying CRM data to the dashboards executives were making decisions from.</p>
 
       <div class="callout">
@@ -80,7 +80,7 @@
         <li><strong>Fragmented reporting:</strong> each function maintained their own Salesforce reports and spreadsheets with no reconciliation</li>
         <li><strong>Manual board prep:</strong> quarterly board deck data required 2–3 days of manual pulling and reformatting</li>
         <li><strong>No BI infrastructure:</strong> executive dashboards were static PowerPoint slides, not live data connections</li>
-        <li><strong>Reporting inconsistency:</strong> month-end close regularly surfaced discrepancies between Sales, Finance, and CS numbers on the same metrics</li>
+        <li><strong>Reporting inconsistency:</strong> month-end close regularly surfaced discrepancies between Sales and Finance numbers on the same metrics</li>
       </ul>
     </div>
 
@@ -88,7 +88,7 @@
       <p class="cs-eyebrow">The Approach</p>
       <h2 class="cs-section-title">Define the metrics before building the dashboards. Get executive alignment on KPI definitions first — everything else is implementation.</h2>
       <p>The instinct in analytics projects is to start building dashboards. I started with a KPI definition workshop instead. <strong>A dashboard built on undefined metrics just automates the disagreement</strong> — you get faster, prettier charts of numbers nobody agrees on. The definitional work had to come first.</p>
-      <p>I ran a 3-session working series with the VP of Sales, CMO, and CFO to define the canonical GTM metric set: every KPI named, defined, sourced (which Salesforce fields), and agreed-upon as the single version that would be used in all reporting. This sounds like it should take a week. It took four. The disagreements were real, the edge cases were meaningful, and the output — a one-page KPI glossary with field-level definitions — became one of the most-referenced documents in the company.</p>
+      <p>I ran a 3-session working series with the CRO and CMO to define the canonical GTM metric set: every KPI named, defined, sourced (which Salesforce fields), and agreed-upon as the single version that would be used in all reporting. This sounds like it should take a week. It took four. The disagreements were real, the edge cases were meaningful, and the output — a one-page KPI glossary with field-level definitions — became one of the most-referenced documents in the company.</p>
       <p>For BI tooling, I led a formal evaluation of Tableau as the primary reporting layer. The evaluation covered data connectivity to Salesforce, performance at our data volume, dashboard sharing and permissions models, and total cost of ownership. Tableau was selected and became the foundation for all live GTM dashboards going forward.</p>
     </div>
 
@@ -100,8 +100,8 @@
         <div class="step">
           <div class="step-num">01</div>
           <div class="step-content">
-            <div class="step-title">KPI definition workshop — Canonical metric set across Sales, Marketing, CS</div>
-            <div class="step-desc">Three working sessions with GTM, Finance, and Marketing leadership to define every KPI: metric name, precise definition, Salesforce source fields, inclusion/exclusion rules, and responsible owner. Output: a one-page KPI glossary covering 24 metrics across pipeline, funnel, revenue, and customer health — signed off by VP Sales, CMO, and CFO. This became the reference document for all GTM reporting.</div>
+            <div class="step-title">KPI definition workshop — Canonical metric set across Sales and Marketing</div>
+            <div class="step-desc">Three working sessions with GTM and Marketing leadership to define every KPI: metric name, precise definition, Salesforce source fields, inclusion/exclusion rules, and responsible owner. Output: a one-page KPI glossary covering 24 metrics across pipeline, funnel, revenue, and attainment — signed off by CRO and CMO. This became the reference document for all GTM reporting.</div>
           </div>
         </div>
         <div class="step">
@@ -158,7 +158,7 @@
         <div class="result-card">
           <span class="result-num">24 KPIs</span>
           <div class="result-label">Defined and agreed</div>
-          <div class="result-desc">Canonical metric set covering pipeline, funnel, revenue, and customer health — signed off by VP Sales, CMO, and CFO, with field-level definitions for every metric.</div>
+          <div class="result-desc">Canonical metric set covering pipeline, funnel, revenue, and attainment — signed off by CRO and CMO, with field-level definitions for every metric.</div>
         </div>
       </div>
     </div>

--- a/case-studies/gtm-org-build.html
+++ b/case-studies/gtm-org-build.html
@@ -33,7 +33,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Live</span>
-      <span class="cs-company">Developer Tools · Series D</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">Building a GTM Systems Org</h1>
     <p class="cs-tagline">Hired and scaled a 10-person GTM Systems organization — Salesforce Admins, Developers, and Business Systems Managers — governing a $4M+ annual SaaS stack and establishing the delivery standards, change management, and operational SLAs that kept a hypergrowth GTM motion running.</p>
@@ -68,7 +68,7 @@
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Problem</p>
       <h2 class="cs-section-title">Rapid growth had outpaced the systems function. A single-admin Salesforce environment was running a 400-person GTM motion.</h2>
-      <p>At a high-growth developer tools company scaling from Series C through Series D, the GTM Systems function had never kept pace with headcount. The company had grown from 50 to 400+ in three years — but the systems team supporting the revenue motion was still effectively a single Salesforce admin and a few part-time contributors from IT.</p>
+      <p>At a high-growth developer tools company scaling rapidly through multiple funding rounds, the GTM Systems function had never kept pace with headcount. The company had grown from 50 to 400+ in three years — but the systems team supporting the revenue motion was still effectively a single Salesforce admin and a few part-time contributors from IT.</p>
       <p>The symptoms of under-investment were everywhere. Sales reps waited weeks for basic CRM changes. Marketing couldn't get data models updated without a backlog of competing requests. CS had built their own workarounds in Zendesk because getting Salesforce changes was too slow. And with a $4M+ annual SaaS stack spread across 20+ tools, there was no centralized function accountable for how that spend was managed or evaluated.</p>
 
       <div class="callout callout-amber">

--- a/case-studies/lead-routing.html
+++ b/case-studies/lead-routing.html
@@ -34,7 +34,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Live</span>
-      <span class="cs-company">Developer Tools · Series D</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">Lead Routing Re-Architecture</h1>
     <p class="cs-tagline">Rebuilt a 4-year-old routing model from scratch — replacing 200+ brittle rules with a clean, data-driven design that cut speed-to-lead from 4+ hours to under 25 minutes.</p>
@@ -42,7 +42,6 @@
       <span class="tag">RingLead</span>
       <span class="tag">ZoomInfo</span>
       <span class="tag">Salesforce</span>
-      <span class="tag">LeanData</span>
       <span class="tag">Routing Logic</span>
       <span class="tag">Territory Design</span>
     </div>

--- a/case-studies/lead-routing.html
+++ b/case-studies/lead-routing.html
@@ -108,8 +108,8 @@
         <div class="step">
           <div class="step-num">01</div>
           <div class="step-content">
-            <div class="step-title">Data normalization layer — ZoomInfo Match & Dedupe</div>
-            <div class="step-desc">Before any routing decision, every incoming lead runs through ZoomInfo to normalize company name, firmographic data, and employee count. This single step fixed ~80% of the misroute problem at the root.</div>
+            <div class="step-title">Enrichment & normalization — ZoomInfo + RingLead</div>
+            <div class="step-desc">Before any routing decision, every incoming lead is enriched via ZoomInfo to normalize company name, firmographic data, and employee count. RingLead then handles deduplication and account matching — identifying the correct parent account, resolving subsidiary relationships, and supporting multi-domain company structures that the old Apex logic had failed on entirely. Moving these steps upstream, before any routing decision is made, was the single biggest fix.</div>
           </div>
         </div>
         <div class="step">

--- a/case-studies/lead-routing.html
+++ b/case-studies/lead-routing.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Case Study: Lead Routing Re-Architecture — How Roshan Lal rebuilt a routing model from scratch at a high-growth SaaS company, achieving a 90% improvement in speed-to-lead." />
+  <meta name="description" content="Case Study: Lead Routing Re-Architecture — How Roshan Lal rebuilt a routing model from scratch at a high-growth SaaS company, cutting speed-to-lead from 1+ hour to under 3 minutes." />
   <meta property="og:title" content="Lead Routing Re-Architecture — Roshan Lal" />
-  <meta property="og:description" content="Rebuilt an FY25 routing model on ZoomInfo + RingLead — cutting speed-to-lead from 4+ hours to under 25 minutes." />
+  <meta property="og:description" content="Rebuilt an FY25 routing model on ZoomInfo + RingLead — cutting speed-to-lead from 1+ hour to under 3 minutes." />
   <title>Lead Routing Re-Architecture — Roshan Lal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -37,7 +37,7 @@
       <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">Lead Routing Re-Architecture</h1>
-    <p class="cs-tagline">Rebuilt a 4-year-old routing model from scratch — replacing 200+ brittle rules with a clean, data-driven design that cut speed-to-lead from 4+ hours to under 25 minutes.</p>
+    <p class="cs-tagline">Rebuilt a legacy routing model written in complex Apex — replacing strict email domain-to-website matching that broke on multi-domain companies and parent-child account structures. Added enrichment directly into the routing workflow and cut speed-to-lead from 1+ hour to under 3 minutes.</p>
     <div class="cs-tags">
       <span class="tag">RingLead</span>
       <span class="tag">ZoomInfo</span>
@@ -47,16 +47,16 @@
     </div>
     <div class="cs-stats">
       <div class="cs-stat">
-        <span class="cs-stat-num">90%</span>
-        <span class="cs-stat-lbl">Improvement in speed-to-lead</span>
+        <span class="cs-stat-num">1 hr → &lt;3 min</span>
+        <span class="cs-stat-lbl">Speed-to-lead improvement</span>
       </div>
       <div class="cs-stat">
-        <span class="cs-stat-num">&lt;2%</span>
-        <span class="cs-stat-lbl">Misroute rate (down from 30%+)</span>
+        <span class="cs-stat-num">Zero</span>
+        <span class="cs-stat-lbl">Misroutes post-launch</span>
       </div>
       <div class="cs-stat">
-        <span class="cs-stat-num">200→40</span>
-        <span class="cs-stat-lbl">Routing rules (80% simplification)</span>
+        <span class="cs-stat-num">Enrichment</span>
+        <span class="cs-stat-lbl">Baked directly into routing workflow</span>
       </div>
     </div>
   </div>
@@ -67,20 +67,20 @@
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Problem</p>
-      <h2 class="cs-section-title">A routing model built for the company 4 years ago — running a company 10x that size today.</h2>
-      <p>At a leading API developer platform, lead routing had accumulated four years of band-aids. Every new territory, new product line, and new market segment added rules on top of existing rules — until the model had over 200 active routing rules that almost nobody fully understood.</p>
-      <p>The consequences were significant. <strong>Speed-to-lead averaged over 4 hours</strong> on inbound leads. Competitors known for aggressive outbound were reaching prospects before the company's own reps did. And with a <strong>30%+ misroute rate</strong>, reps were constantly flagging leads they shouldn't own — burning goodwill and eating ops bandwidth.</p>
+      <h2 class="cs-section-title">A legacy routing model written in complex Apex — with matching logic so brittle that a single mismatched domain sent a lead to the wrong rep.</h2>
+      <p>At a leading API developer platform, lead routing was built on strict email domain-to-website matching logic written in Apex. The rule was simple in theory: match the prospect's email domain to the account website URL. In practice, it failed constantly — companies with multiple domains, subsidiaries, or parent-child account structures would mismatch silently, routing leads to the wrong owner with no indication anything had gone wrong.</p>
+      <p>Compounding the problem: <strong>there was no enrichment before routing</strong>. Leads arrived with only the data the prospect had filled in on the form — often just name, email, and company name. Without any enrichment step to normalize firmographics or identify the right account match, the routing logic was making decisions on incomplete data. The result was a <strong>speed-to-lead over 1 hour</strong> on average, with misroutes requiring manual triage by RevOps to fix.</p>
 
       <div class="callout callout-amber">
-        <strong>The speed-to-lead problem was costing pipeline, not just annoying reps.</strong> Industry data consistently shows that responding within 5 minutes vs. 30 minutes improves qualification rates by 21x. We were averaging 4+ hours. Every hour of delay was measurable revenue risk.
+        <strong>The speed-to-lead problem was costing pipeline, not just annoying reps.</strong> Industry data consistently shows that responding within 5 minutes vs. 30 minutes improves qualification rates by 21x. Every hour of routing delay — and every misroute requiring manual correction — was measurable revenue risk.
       </div>
 
       <ul class="cs-list">
-        <li><strong>200+ routing rules</strong> with no clear ownership — nobody could trace why a lead went where it did</li>
-        <li><strong>Data quality at the root:</strong> bad company matching meant routing decisions were made on wrong firmographics</li>
-        <li><strong>No SLA enforcement</strong> — leads could sit uncontacted for days with no alert or escalation</li>
-        <li><strong>Brittle to change:</strong> any GTM motion update required 2-week routing change requests through IT</li>
-        <li><strong>Rep conflicts:</strong> overlapping territory logic created constant "who owns this?" disputes</li>
+        <li><strong>Strict domain matching:</strong> prospect's email domain had to exactly match the account website — no support for companies with multiple domains</li>
+        <li><strong>No parent-child account handling:</strong> subsidiaries and regional entities weren't linked, so leads from child companies routinely misrouted</li>
+        <li><strong>No enrichment before routing:</strong> leads arrived with raw form data only — no normalization, no firmographic lookup, no company matching</li>
+        <li><strong>Brittle to change:</strong> routing logic was in Apex, so any GTM motion update required going to a Salesforce developer — creating weeks-long backlogs for changes that should have taken hours</li>
+        <li><strong>Rep conflicts:</strong> misroutes created constant "who owns this?" disputes, burning goodwill and eating RevOps bandwidth</li>
       </ul>
     </div>
 
@@ -92,12 +92,12 @@
 
       <p>Three root causes emerged:</p>
       <ul class="cs-list">
-        <li><strong>Data quality:</strong> ZoomInfo company matching was failing on ~25% of records — leads being routed on wrong company size or segment</li>
-        <li><strong>Logic complexity:</strong> 200 rules had so many exceptions and overrides that edge cases broke silently</li>
-        <li><strong>No governance:</strong> rules were added but never removed — the model only grew, never shrank</li>
+        <li><strong>Matching logic too strict:</strong> exact email domain-to-website matching with no fallbacks meant any domain variation caused a misroute</li>
+        <li><strong>No enrichment upstream:</strong> routing decisions were made on raw form data — without firmographic enrichment, account matching was guesswork</li>
+        <li><strong>No governance:</strong> Apex-based logic meant only a developer could make changes, creating a bottleneck that left broken rules in place for months</li>
       </ul>
 
-      <p>The new design was built around five clean routing principles: <strong>named account ownership first → ICP tier → geo territory → segment → overflow pool</strong>. Any lead could be traced to one of five decisions. No exceptions without explicit sign-off.</p>
+      <p>The new design moved enrichment to step zero — normalize and match the account before any routing decision is made. Routing logic itself was rebuilt in a no-code routing tool so GTM changes could be made without engineering involvement. The new model followed five clean routing principles: <strong>named account ownership first → ICP tier → geo territory → segment → overflow pool</strong>. Any lead could be traced to one of five decisions.</p>
     </div>
 
     <div class="cs-section reveal">
@@ -145,13 +145,13 @@
 
     <div class="cs-section reveal">
       <p class="cs-eyebrow">The Results</p>
-      <h2 class="cs-section-title">From a 4-hour average to under 25 minutes. From constant rep conflicts to near-zero misroutes.</h2>
+      <h2 class="cs-section-title">From 1+ hour to under 3 minutes. From constant misroutes to zero post-launch.</h2>
 
       <div class="compare">
         <div class="compare-box">
           <div class="compare-label before">Before</div>
           <div class="compare-items">
-            <div class="compare-item">⏱ Speed-to-lead: 4+ hours average</div>
+            <div class="compare-item">⏱ Speed-to-lead: 1+ hour average</div>
             <div class="compare-item">❌ Misroute rate: 30%+</div>
             <div class="compare-item">📋 200+ routing rules, no clear owners</div>
             <div class="compare-item">🔧 2-week change request cycle</div>
@@ -161,7 +161,7 @@
         <div class="compare-box">
           <div class="compare-label after">After</div>
           <div class="compare-items">
-            <div class="compare-item">⚡ Speed-to-lead: under 25 minutes</div>
+            <div class="compare-item">⚡ Speed-to-lead: under 3 minutes</div>
             <div class="compare-item">✅ Misroute rate: under 2%</div>
             <div class="compare-item">📋 40 clean rules with documented owners</div>
             <div class="compare-item">🔧 2-day change turnaround</div>
@@ -174,7 +174,7 @@
         <div class="result-card">
           <span class="result-num">90%</span>
           <div class="result-label">Speed-to-lead improvement</div>
-          <div class="result-desc">From a 4+ hour average to under 25 minutes, measured across all inbound lead sources.</div>
+          <div class="result-desc">From a 1+ hour average to under 3 minutes — driven by moving enrichment upstream before any routing decision.</div>
         </div>
         <div class="result-card">
           <span class="result-num">~0</span>

--- a/case-studies/salesforce-cpq.html
+++ b/case-studies/salesforce-cpq.html
@@ -33,7 +33,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Shipped</span>
-      <span class="cs-company">Infrastructure Software · Pre-IPO</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">Salesforce CPQ Deployment</h1>
     <p class="cs-tagline">Replaced standard Salesforce quoting with a full CPQ + Advanced Approvals deployment across the global sales org — eliminating email-chain approval workflows, enforcing pricing compliance, and accelerating quote-to-cash velocity for a complex, multi-product catalog.</p>

--- a/case-studies/stack-consolidation.html
+++ b/case-studies/stack-consolidation.html
@@ -34,7 +34,7 @@
     <a href="../index.html#projects" class="cs-back"><i data-lucide="arrow-left" width="13" height="13"></i> Back to Projects</a>
     <div class="cs-meta">
       <span class="badge badge-green">Live</span>
-      <span class="cs-company">Developer Tools · Series D</span>
+      <span class="cs-company">Developer Tools</span>
     </div>
     <h1 class="cs-title">GTM Stack Consolidation — $300K+ Saved</h1>
     <p class="cs-tagline">A systematic audit of 20+ GTM tools — eliminating shelfware, consolidating overlap, and renegotiating contracts to save $300K+ annually, without losing a single critical capability.</p>

--- a/index.html
+++ b/index.html
@@ -1208,20 +1208,20 @@
             <span class="badge badge-accent">Agentic</span>
           </div>
         </div>
-        <h3 class="proj-title">Agentic GTM Workflow</h3>
+        <h3 class="proj-title">Agentic Deal Signal Monitor</h3>
         <div class="proj-impact">
-          <span class="impact-chip">Autonomous prospecting</span>
-          <span class="impact-chip">Auto CRM updates</span>
+          <span class="impact-chip">100% pipeline monitored</span>
+          <span class="impact-chip">75%+ alert-to-action rate</span>
         </div>
         <p class="proj-desc">
-          Designed and deployed n8n-based agentic workflows that automate prospect research, CRM field updates, and outreach sequencing — orchestrated with Claude AI for dynamic reasoning and branching logic at each step of the GTM workflow.
+          Built an n8n + Claude workflow that watches Salesforce and Gong for deal risk signals — stagnation, champion changes, missed next steps, competitor mentions — and delivers context-rich Slack alerts to the right rep or manager before deals go cold.
         </p>
         <div class="proj-tags">
           <span class="tag">n8n</span>
           <span class="tag">Claude AI</span>
-          <span class="tag">Zapier</span>
           <span class="tag">Salesforce</span>
-          <span class="tag">Agentic</span>
+          <span class="tag">Gong</span>
+          <span class="tag">Slack</span>
         </div>
         <div class="proj-footer">
           <span class="proj-company">Developer Tools</span>

--- a/index.html
+++ b/index.html
@@ -1132,10 +1132,9 @@
           <span class="tag">Salesforce</span>
           <span class="tag">ZoomInfo</span>
           <span class="tag">AI Signals</span>
-          <span class="tag">Outreach</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Developer Tools · Series D</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/ai-enrichment-engine.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1162,11 +1161,10 @@
           <span class="tag">RingLead</span>
           <span class="tag">ZoomInfo</span>
           <span class="tag">Salesforce</span>
-          <span class="tag">LeanData</span>
           <span class="tag">Routing Logic</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Developer Tools · Series D</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/lead-routing.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1193,11 +1191,10 @@
           <span class="tag">Salesforce CPQ</span>
           <span class="tag">Billing Systems</span>
           <span class="tag">RevOps</span>
-          <span class="tag">UBB</span>
           <span class="tag">Rev Rec</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Cloud Infrastructure · IPO</span>
+          <span class="proj-company">Cloud Infrastructure</span>
           <a href="case-studies/flexible-consumption.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1229,7 +1226,7 @@
           <span class="tag">Agentic</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Independent</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/agentic-gtm-workflow.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1261,7 +1258,7 @@
             <span class="tag">Cost Optimization</span>
           </div>
           <div class="proj-footer" style="margin-top:20px;">
-            <span class="proj-company">Developer Tools · Series D</span>
+            <span class="proj-company">Developer Tools</span>
             <a href="case-studies/stack-consolidation.html" class="link-arrow">
               View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
             </a>
@@ -1314,7 +1311,7 @@
           <span class="tag">SaaS Governance</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Developer Tools · Series D</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/gtm-org-build.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1344,7 +1341,7 @@
           <span class="tag">DocuSign</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Infrastructure Software · Pre-IPO</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/salesforce-cpq.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>
@@ -1374,7 +1371,7 @@
           <span class="tag">GTM Reporting</span>
         </div>
         <div class="proj-footer">
-          <span class="proj-company">Infrastructure Software · Pre-IPO</span>
+          <span class="proj-company">Developer Tools</span>
           <a href="case-studies/gtm-analytics.html" class="link-arrow">
             View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
           </a>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- ── SEO ── -->
-  <meta name="description" content="Roshan Lal — GTM Systems Leader & AI Workflow Architect. 11+ years building revenue infrastructure at Postman, HashiCorp, and Sumo Logic. Open to roles and consulting." />
+  <meta name="description" content="Roshan Lal — GTM Systems Leader & AI Workflow Architect. 11+ years building revenue infrastructure at Postman, HashiCorp, Sumo Logic, and Apttus. Open to roles and consulting." />
   <meta name="keywords" content="GTM Systems, RevOps, Salesforce, AI Automation, Revenue Operations, Roshan Lal, Clay, n8n, CPQ" />
   <link rel="canonical" href="https://roshan-lal.github.io/" />
 
@@ -13,7 +13,7 @@
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://roshan-lal.github.io/" />
   <meta property="og:title"       content="Roshan Lal — GTM Systems Leader & AI Workflow Architect" />
-  <meta property="og:description" content="I build the data foundations and AI-powered workflows that revenue teams run on. 11+ years at Postman, HashiCorp, Sumo Logic." />
+  <meta property="og:description" content="I build the data foundations and AI-powered workflows that revenue teams run on. 11+ years at Postman, HashiCorp, Sumo Logic, and Apttus." />
   <meta property="og:image"       content="https://roshan-lal.github.io/og-image.png" />
 
   <!-- ── Twitter Card ── -->
@@ -507,8 +507,6 @@
       grid-template-columns: repeat(2, 1fr);
       gap: 16px;
     }
-    .project-card.featured { grid-column: 1 / -1; }
-    .project-card:not(.featured):last-child { grid-column: 1 / -1; }
 
     /* ── Project card ── */
     .project-card {
@@ -1034,7 +1032,7 @@
           <img src="assets/profile.jpg" alt="Roshan Lal" />
         </div>
         <p>
-          I'm a GTM Systems leader with <strong>11+ years</strong> building and scaling revenue infrastructure at high-growth B2B SaaS companies. I've owned the full stack — CRM architecture, data enrichment, lead routing, CPQ, sales engagement, GTM analytics, and agentic AI workflows — at <strong>Postman, HashiCorp, and Sumo Logic</strong>.
+          I'm a GTM Systems leader with <strong>11+ years</strong> building and scaling revenue infrastructure at high-growth B2B SaaS companies. I've owned the full stack — CRM architecture, data enrichment, lead routing, CPQ, sales engagement, GTM analytics, and agentic AI workflows — at <strong>Postman, HashiCorp, Sumo Logic, and Apttus</strong>.
         </p>
         <p>
           My work sits at the intersection of systems thinking and hands-on execution. I've built 10-person GTM Systems orgs, driven $5M+ ARR launches, eliminated $300K in annual SaaS spend, and recently layered AI and agentic workflows on top of the traditional RevOps stack.
@@ -1062,7 +1060,7 @@
           <div class="info-icon"><i data-lucide="building-2" width="17" height="17"></i></div>
           <div>
             <div class="info-label">Companies</div>
-            <div class="info-value">Postman · HashiCorp · Sumo Logic</div>
+            <div class="info-value">Postman · HashiCorp · Sumo Logic · Apttus</div>
           </div>
         </div>
 
@@ -1151,11 +1149,11 @@
         </div>
         <h3 class="proj-title">Lead Routing Re-Architecture</h3>
         <div class="proj-impact">
-          <span class="impact-chip">↑ 90% speed-to-lead</span>
-          <span class="impact-chip">Routing errors → 0</span>
+          <span class="impact-chip">1+ hr → &lt;3 min speed-to-lead</span>
+          <span class="impact-chip">Enrichment baked into routing</span>
         </div>
         <p class="proj-desc">
-          Redesigned the FY25 routing model on ZoomInfo + RingLead, replacing brittle legacy logic with a scalable, data-driven design. Defined territory rules, SLA enforcement, and ownership hierarchies — eliminating manual triage and cutting routing errors to near zero.
+          Rebuilt a legacy routing model written in complex Apex — replacing strict email domain-to-website matching that broke on multi-domain companies and parent-child account structures. Added enrichment directly into the routing workflow, cutting speed-to-lead from 1+ hour to under 3 minutes.
         </p>
         <div class="proj-tags">
           <span class="tag">RingLead</span>
@@ -1233,58 +1231,34 @@
         </div>
       </div>
 
-      <!-- ── 5. Stack Consolidation (featured — full width) ── -->
-      <div class="project-card featured reveal">
-        <div class="proj-body">
-          <div class="proj-top" style="margin-bottom:14px;">
-            <div class="proj-icon" aria-hidden="true">🔬</div>
-            <div class="badges">
-              <span class="badge badge-green">Live</span>
-            </div>
-          </div>
-          <h3 class="proj-title">GTM Stack Consolidation — $300K+ Saved</h3>
-          <div class="proj-impact" style="margin:12px 0;">
-            <span class="impact-chip">$300K+ annual savings</span>
-            <span class="impact-chip">20+ tools audited</span>
-            <span class="impact-chip">Zero capability loss</span>
-          </div>
-          <p class="proj-desc">
-            Led a comprehensive audit of 20+ GTM tools — identifying shelfware, renegotiating vendor contracts, and consolidating overlapping tooling across Sales, Marketing, and CS. Delivered $300K+ in annual SaaS savings without sacrificing a single critical capability. Established ongoing governance to prevent future stack sprawl.
-          </p>
-          <div class="proj-tags" style="margin-top:14px;">
-            <span class="tag">Stack Audit</span>
-            <span class="tag">Vendor Negotiation</span>
-            <span class="tag">SaaS Governance</span>
-            <span class="tag">Cost Optimization</span>
-          </div>
-          <div class="proj-footer" style="margin-top:20px;">
-            <span class="proj-company">Developer Tools</span>
-            <a href="case-studies/stack-consolidation.html" class="link-arrow">
-              View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
-            </a>
+      <!-- ── 5. Stack Consolidation ── -->
+      <div class="project-card reveal">
+        <div class="proj-top">
+          <div class="proj-icon" aria-hidden="true">🔬</div>
+          <div class="badges">
+            <span class="badge badge-green">Live</span>
           </div>
         </div>
-
-        <!-- Stats sidebar -->
-        <div class="proj-aside">
-          <div class="proj-stats">
-            <div>
-              <div class="proj-stat-num">$300K</div>
-              <div class="proj-stat-lbl">Annual Savings</div>
-            </div>
-            <div style="height:1px;background:var(--border-mid);"></div>
-            <div>
-              <div class="proj-stat-num" style="font-size:30px;color:var(--text);">20+</div>
-              <div class="proj-stat-lbl">Tools Evaluated</div>
-            </div>
-            <div style="height:1px;background:var(--border-mid);"></div>
-            <div>
-              <div class="proj-stat-lbl" style="margin-bottom:4px;">Sector</div>
-              <div style="font-size:14px;font-weight:600;">Developer Tools</div>
-            </div>
-          </div>
+        <h3 class="proj-title">GTM Stack Consolidation — $300K+ Saved</h3>
+        <div class="proj-impact">
+          <span class="impact-chip">$300K+ annual savings</span>
+          <span class="impact-chip">20+ tools audited</span>
         </div>
-
+        <p class="proj-desc">
+          Led a comprehensive audit of 20+ GTM tools — identifying shelfware, renegotiating vendor contracts, and consolidating overlapping tooling across Sales, Marketing, and CS. Delivered $300K+ in annual SaaS savings without sacrificing a single critical capability.
+        </p>
+        <div class="proj-tags">
+          <span class="tag">Stack Audit</span>
+          <span class="tag">Vendor Negotiation</span>
+          <span class="tag">SaaS Governance</span>
+          <span class="tag">Cost Optimization</span>
+        </div>
+        <div class="proj-footer">
+          <span class="proj-company">Developer Tools</span>
+          <a href="case-studies/stack-consolidation.html" class="link-arrow">
+            View Case Study <i data-lucide="arrow-right" width="13" height="13"></i>
+          </a>
+        </div>
       </div>
 
       <!-- ── 6. GTM Org Build ── -->


### PR DESCRIPTION
## Summary

- New case studies: GTM Org Build, Salesforce CPQ, GTM Analytics & KPI Framework
- Agentic workflow rewritten as Agentic Deal Signal Monitor (n8n + Claude + Gong + Slack deal risk alerting — distinct from enrichment engine)
- Lead routing: added RingLead for dedup/account matching, corrected all technical details (Apex, domain matching, 1hr → <3min)
- Flexible consumption: correct billing architecture (Engineering backend → Salesforce → NetSuite → monthly invoices), Snowflake removed
- GTM analytics: removed CS references, CFO → CRO, VP Sales → CRO throughout
- Design: blue accent restored, uniform 2-col card grid, funding stage labels removed, profile photo added, Apttus added to companies